### PR TITLE
chore!(dev/image): initialize new Dockerfile for tunnel server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mdrop
 
-WebRTC CLI (soon GUI) Based File Transfer. Inspired by ShareDrop and Apple AirDrop. Written on Golang and C#.
+TCP-over-SSH P2P Tunneling Based File Transfer. Inspired by ShareDrop and Apple AirDrop. Written on Golang and C#.
 
 *Reserved.*

--- a/tunnel_image/Dockerfile
+++ b/tunnel_image/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/library/alpine:latest
+
+RUN set -ex; \
+  apk update; \
+  apk add openssh bash lsof;
+
+COPY ./start.sh /
+COPY ./tunnel.conf /etc/ssh/sshd_config.d/
+COPY ./entrypoint.sh /
+
+RUN adduser tunnel -HD; \
+  passwd tunnel -d; \
+  ssh-keygen -A;
+
+EXPOSE 22
+
+ENTRYPOINT /entrypoint.sh

--- a/tunnel_image/README.md
+++ b/tunnel_image/README.md
@@ -1,0 +1,2 @@
+# Image
+For this image, you just need to expose 22/tcp on the host.

--- a/tunnel_image/entrypoint.sh
+++ b/tunnel_image/entrypoint.sh
@@ -1,0 +1,10 @@
+#1/bin/sh
+
+# Run MOTD on logs
+echo "SSHD successfully launched. For reference, you can use this command to remote port to the container:"
+echo "    ssh -R <remote>:127.0.0.1:<local> -p <port> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tunnel@localhost <remote>"
+echo "Or listening port from the container:"
+echo "    ssh -L <local>:127.0.0.1:<remote> -p <port> -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tunnel@localhost <remote>"
+
+# Run and detach SSHD
+/usr/sbin/sshd -D

--- a/tunnel_image/start.sh
+++ b/tunnel_image/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+args="$(echo "$SSH_ORIGINAL_COMMAND" | awk -F' ' '{print NF}')"
+
+if [ $args != "1" ]; then
+	echo "WRONG_USAGE_EXCEPTION"
+	exit 1
+fi
+
+# MOTD
+port="$(echo $SSH_ORIGINAL_COMMAND | awk '{ print $1 }')"
+echo "Connected! $port"
+
+tail -f /dev/null

--- a/tunnel_image/tunnel.conf
+++ b/tunnel_image/tunnel.conf
@@ -1,0 +1,8 @@
+PermitRootLogin no
+
+Match User tunnel
+    X11Forwarding no
+    PermitTTY no
+    AllowTcpForwarding yes
+    ForceCommand /start.sh
+    PermitEmptyPasswords yes


### PR DESCRIPTION
- Create tunnel server based on Alpine x64 with OpenSSH daemon.
- Disable `root` login on the server and disable TTY Interactive for `tunnel` user.
- Create MOTD + Port for parsing on client/server side.